### PR TITLE
Passing the json example as a local variable to the example template

### DIFF
--- a/app/views/apitome/docs/_all_examples.html.erb
+++ b/app/views/apitome/docs/_all_examples.html.erb
@@ -2,8 +2,7 @@
   <section class="example" id="<%= id_for(resource['name']) %>">
     <% resource['examples'].each do |example| %>
       <article id="<%= id_for(example['link'].gsub('.json', '')) %>">
-        <% set_example(example['link'].gsub('.json', '')) %>
-        <%= render partial: 'example' %>
+        <%= render partial: 'example', locals: { example: set_example(example['link'].gsub('.json', '')) } %>
       </article>
     <% end %>
   </section>


### PR DESCRIPTION
For some reason when rendering the example partial inside the loop, it doesn't call
the example helper method on the controller, it calls instead a nil local variable
breaking the rendering of the single page template with: `undefined method`[]' for nil:NilClass`inside the`_example` partial.

At first I thought it was the local variable from the loop `example` that was conflicting, but it doesn't really make sense, since the context of the partial rendering is different. Must be some kind of auto generated local variable based on the template name.

Either way, this was the quickest fix I thought of that wouldn't require changing a lot of other stuff :)

Thanks!
