### PR TITLE
Add utf-8 magic comment to gemspec

### DIFF
--- a/apitome.gemspec
+++ b/apitome.gemspec
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
 
 # Maintain your gem's version:


### PR DESCRIPTION
When loading the gem from Github I get a `apitome.gemspec:13: invalid multibyte char (US-ASCII)` error due to non-ascii characters /iˈpitəmē/.

Adding a utf-8 magic comment in gemspec fixes the error.
