### PR TITLE
Adding support for API responses with no JSON output. e.g. head(:ok)

### DIFF
--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -41,6 +41,9 @@ class Apitome::DocsController < ActionController::Base
     else
       body
     end
+  rescue JSON::ParserError
+    return body if body == " "
+    raise JSON::ParserError
   end
 
   def param_headers(params)


### PR DESCRIPTION
In an attempt to prettify API responses which have no output, the pretty generate method throws a JSON::ParserError.  

This allows them to pass through.  This supports RSpec API Documentation output for requests which respond with just a status.
