### PR TITLE
Use example['resource'] in Docs#show

### DIFF
--- a/app/views/apitome/docs/show.html.erb
+++ b/app/views/apitome/docs/show.html.erb
@@ -1,2 +1,2 @@
-<h2 class="resource-name"><%= resource['name'] %></h2>
+<h2 class="resource-name"><%= example['resource'] %></h2>
 <%= render 'example' %>


### PR DESCRIPTION
I'm using the master branch version in a project and got a:

``` ruby
NameError in Apitome::Docs#show
Showing ..../.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/bundler/gems/apitome-ef501fd61cd7/app/views/apitome/docs/show.html.erb where line #1 raised:

undefined local variable or method 'resource' for #<#<Class:0x007fc3b6656270>:0x007fc3baa10448>
Extracted source (around line #1):
1 <h2 class="resource-name"><%= resource['name'] %></h2>
2 <%= render 'example' %>
```

I'm not familiar on how the gem works/should work but using `example['resource']` fixes that.
