### PR TITLE
Added UTF-8 encoding to resolve an issue with multibyte ASCII

### DIFF
--- a/apitome.gemspec
+++ b/apitome.gemspec
@@ -1,3 +1,4 @@
+# encoding: utf-8
 $:.push File.expand_path('../lib', __FILE__)
 
 # Maintain your gem's version:


### PR DESCRIPTION
The multibyte ASCII characters in the summary were causing an issue with bundler on certain RVM installations. By adding UTF-8 encoding this resolves the issue.  
