### PR TITLE
Fix custom highlight.js CSS styles.

### DIFF
--- a/app/assets/stylesheets/apitome/application.css
+++ b/app/assets/stylesheets/apitome/application.css
@@ -1,6 +1,5 @@
 /*
  *= require apitome/bootstrap.min
- *= require apitome/highlight_themes/default
  */
 
 body {

--- a/app/views/layouts/apitome/application.html.erb
+++ b/app/views/layouts/apitome/application.html.erb
@@ -4,6 +4,7 @@
   <title><%= Apitome.configuration.title %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <%= stylesheet_link_tag    Apitome.configuration.css_override || 'apitome/application', media: 'all' %>
+  <%= stylesheet_link_tag    Apitome.configuration.code_theme_url, media: 'all' %>
   <%= javascript_include_tag Apitome.configuration.js_override || 'apitome/application' %>
 </head>
 <body class="<%= Apitome.configuration.single_page ? 'single-page' : '' %>">

--- a/lib/apitome/configuration.rb
+++ b/lib/apitome/configuration.rb
@@ -19,6 +19,10 @@ module Apitome
     def self.root=(path)
       @@root = Pathname.new(path.to_s) if path.present?
     end
+
+    def self.code_theme_url
+      "apitome/highlight_themes/#{@@code_theme}"
+    end
   end
 
   mattr_accessor :configuration


### PR DESCRIPTION
First thanks this is great tool and works really well for my needs.

I noticed the highlight.js custom styling didn’t work and I really like the ‘github’ style.  Changing the configuration property ‘code_theme’ didn’t have any effect hence this PR.

I’ve tested this locally and it works as expected, let me know if i’ve missed something in the docs.
