### PR TITLE
Show response fields description

### DIFF
--- a/app/views/apitome/docs/_example.html.erb
+++ b/app/views/apitome/docs/_example.html.erb
@@ -16,6 +16,7 @@
 
     <h3><%= t(:response) %></h3>
     <div class="response">
+      <%= render partial: 'apitome/docs/response_fields',   locals: {params: example['response_fields']}  if example['response_fields'].size > 0 %>
       <%= render partial: 'apitome/docs/status',   locals: {request: request, index: index} %>
       <%= render partial: 'apitome/docs/headers',  locals: {request: request, index: index, headers: request['response_headers']} %>
       <%= render partial: 'apitome/docs/body',     locals: {request: request, index: index, body: request['response_body'], type: request['response_content_type']} if request['response_body'] %>

--- a/app/views/apitome/docs/_response_fields.html.erb
+++ b/app/views/apitome/docs/_response_fields.html.erb
@@ -1,0 +1,27 @@
+<section class="params">
+  <h3><%= t(:response_fields) %></h3>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <tr>
+        <% param_headers(params).each do |title| %>
+          <th><%= title %></th>
+        <% end %>
+      </tr>
+      <% params.each do |param| %>
+        <tr>
+          <td class="name">
+            <% if param['scope'] %>
+              <%= "#{param['scope']}[#{param['name']}]" %>
+            <% else %>
+              <%= param['name'] %>
+            <% end %>
+          </td>
+          <td class="description"><%= param['description'] %></td>
+          <% param_extras(params).each do |extra| %>
+            <td class="extra"><%= param[extra] %></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,5 +7,6 @@ en:
   readme: README
   request: Request
   response: Response
+  response_fields: Response Fields
   route: Route
   status: Status


### PR DESCRIPTION
Rspec Api Documentation implements [respond_field](https://github.com/zipmark/rspec_api_documentation/#response_field) helper to
describe response.
Added 'Response Fields' partial for showing fields descriptions.
It looks almost like params partial (without 'required').
