### PR TITLE
HTTP cache documentation

### DIFF
--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -14,6 +14,10 @@ class Apitome::DocsController < ActionController::Base
   ]
 
   def index
+    @@doc_etag ||= Digest::MD5.hexdigest(Dir[Apitome.configuration.doc_path.join('**', '*.json')].collect do |file|
+                     Digest::MD5.file(file).hexdigest
+                   end.join)
+    fresh_when etag: @@doc_etag
   end
 
   def show

--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -14,7 +14,7 @@ class Apitome::DocsController < ActionController::Base
   ]
 
   def index
-    @@doc_etag ||= Digest::MD5.hexdigest(Dir[Apitome.configuration.doc_path.join('**', '*.json')].collect do |file|
+    @@doc_etag ||= Digest::MD5.hexdigest(Dir[Pathname.new(Apitome.configuration.doc_path).join('**', '*.json')].collect do |file|
                      Digest::MD5.file(file).hexdigest
                    end.join)
     fresh_when etag: @@doc_etag


### PR DESCRIPTION
Since we know, when the documentation changes based on the content of the files, I suggest something like this, to leverage http caching. This means that we don't have to rerender the documentation partials and templates again and again. 

I'm aware that the class method isn't pretty, but this is more of an idea than a complete implementation. 
