### PR TITLE
Render partial example for docs show action.

### DIFF
--- a/app/views/apitome/docs/_example.html.erb
+++ b/app/views/apitome/docs/_example.html.erb
@@ -17,7 +17,7 @@
 
     <h3><%= t(:response) %></h3>
     <div class="response">
-      <%= link_to('Simulated Response', "#{Apitome.configuration.mount_at}/simulate/#{example['link'].gsub('.json', '')}") if example['link'] %>
+      <%= link_to('Simulated Response', "#{Apitome.configuration.mount_at}/simulate/#{link}") unless link.empty? %>
       <%= render partial: 'apitome/docs/response_fields', locals: {params: example['response_fields']} if example['response_fields'].size > 0 %>
       <%= render partial: 'apitome/docs/status',          locals: {request: request, index: index} %>
       <%= render partial: 'apitome/docs/headers',         locals: {request: request, index: index, headers: request['response_headers']} %>

--- a/app/views/apitome/docs/show.html.erb
+++ b/app/views/apitome/docs/show.html.erb
@@ -1,2 +1,2 @@
 <h1 class="resource-name"><%= example['resource'] %></h1>
-<%= render 'example', locals: { example: example } %>
+<%= render partial: 'example', locals: { example: example, link: example['link'].to_s.gsub('.json', '') } %>


### PR DESCRIPTION
The show template should render the example template as a partial since
we are passing a `locals` hash. This also fixes some issues with
displaying a link when it is not there.