### PR TITLE
Add 'active' classes to active navigation items

### DIFF
--- a/app/helpers/apitome/docs_helper.rb
+++ b/app/helpers/apitome/docs_helper.rb
@@ -8,4 +8,16 @@ module Apitome::DocsHelper
       end
     end.join
   end
+
+  def resource_link(resource)
+    "#{Apitome.configuration.mount_at}/#{resource['examples'].first['link'].gsub(/\.json$/, '')}"
+  end
+
+  def example_link(example)
+    "#{Apitome.configuration.mount_at}/#{example['link'].gsub(/\.json$/, '')}"
+  end
+
+  def link_active?(link)
+    current_page?(url_for(link))
+  end
 end

--- a/app/views/apitome/docs/_navigation.html.erb
+++ b/app/views/apitome/docs/_navigation.html.erb
@@ -18,10 +18,12 @@
           <% end %>
         </ul>
       <% else %>
-        <%= link_to resource['name'], "#{Apitome.configuration.mount_at}/#{resource['examples'].first['link'].gsub(/\.json$/, '')}" %>
+        <%= link_to resource['name'], resource_link(resource), class: "#{link_active?(resource_link(resource)) ? 'active' : ''}" %>
         <ul class="nav">
           <% resource['examples'].each do |example| %>
-            <li><%= link_to example['description'], "#{Apitome.configuration.mount_at}/#{example['link'].gsub(/\.json$/, '')}" %></li>
+            <li class="<%= link_active?(example_link(example)) ? 'active' : '' %>">
+              <%= link_to example['description'], example_link(example) %>
+            </li>
           <% end %>
         </ul>
       <% end %>

--- a/spec/helpers/docs_helper_spec.rb
+++ b/spec/helpers/docs_helper_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+describe Apitome::DocsHelper, type: :helper do
+  describe "#resource_link" do
+    let(:resource) do
+      {
+        'examples' => [
+          { 'link' => 'something.json' }
+        ]
+      }
+    end
+    subject { helper.resource_link(resource)}
+
+    it 'strips the file ending' do
+      expect(subject).to eq '/api/docs/something'
+    end
+  end
+
+  describe "#example_link" do
+    let(:example) do
+      { 'link' => 'an-example.json' }
+    end
+    subject { helper.example_link(example)}
+
+    it 'strips the file ending' do
+      expect(subject).to eq '/api/docs/an-example'
+    end
+  end
+end
+


### PR DESCRIPTION
We have a somewhat long docs navigation and it would be super useful to
highlight the active group and the active item in the navigation.

This change adds these classes and allows the styling of active navigation
items in CSS overrides.

The only problem I see currently is that there is already a CSS rule in
the existing Apitome CSS that will make the current example item bold
if this gets merged.

Let me know if you are unhappy with anything and I'm happy to fix any
issues.

--
It looks like there is an issue with the spec_helper and the Code Climate test reporter, that is causing the specs to fail.