### PR TITLE
Remove test files from built gem

### DIFF
--- a/apitome.gemspec
+++ b/apitome.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files       = Dir["{app,config,lib,vendor}/**/*"] + ["MIT.LICENSE", "README.md"]
-  s.test_files  = Dir["{spec}/**/*"]
 
   s.add_dependency "railties"
   s.add_development_dependency "rspec_api_documentation"


### PR DESCRIPTION
We've found this gem install 18mb of spec filed (in the `dummy/` directory).

This is a problem, particularly, on Heroku.

The utility of including test files on a gem is not yet clear, but changes to rubygems in this regard are being deferred for compatibility reasons. Please check [this issue](https://github.com/rubygems/rubygems/issues/735)