### PR TITLE
Abandon deprecated CodeClimate reporter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
 
 # require "simplecov"
 # SimpleCov.start


### PR DESCRIPTION
CodeClimate deprecated this reporter:

> This usage of the Code Climate Test Reporter is now deprecated. Since version
> 1.0, we now require you to run `SimpleCov` in your test/spec helper, and then
> run the provided `codeclimate-test-reporter` binary separately to report your
> results to Code Climate.
>
> More information here: https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md

Specs keep failing, for they failed in `master`.