### PR TITLE
clicking a resource in single-page navigation links to the top of the resource section

### DIFF
--- a/app/views/apitome/docs/_navigation.html.erb
+++ b/app/views/apitome/docs/_navigation.html.erb
@@ -11,7 +11,7 @@
   <% resources.each do |resource| %>
     <li>
       <% if Apitome.configuration.single_page %>
-        <a href="#<%= id_for(resource['examples'].first['link']) %>"><%= resource['name'] %></a>
+        <a href="#<%= id_for(resource['name']) %>"><%= resource['name'] %></a>
         <ul class="nav">
           <% resource['examples'].each do |example| %>
             <li><%= link_to example['description'], "##{id_for(example['link'])}" %></li>


### PR DESCRIPTION
The RAD gem now includes the ability to add explanations at the top of the resource section.  The single-page navigation bar lists the resource sections.  Currently, clicking a resource section will take you to the first example in that section, not the top of the section itself. This skips the name of the resource, and any explanation provided.

This change ensures that the user sees the top of the section, including title and explanation, when clicking a resource name in the navigation bar.