### PR TITLE
Parent controller config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ After installation, your app will have an apitome initializer (app/config/initia
   <b>default:</b> <code>"doc/api"</code>
 </dd>
 
+<dt> parent_controller </dt><dd>
+  Set a parent controller that Apitome::DocsController inherits from. Useful if you want to use a custom `before_action`.<br/>
+
+  <b>default:</b> <code>"ActionController::Base"</code>
+</dd>
+
 <dt> title </dt><dd>
   The title of the documentation -- If your project has a name, you'll want to put it here.<br/>
 

--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -1,6 +1,6 @@
 require 'open-uri'
 
-class Apitome::DocsController < ActionController::Base
+class Apitome::DocsController < Apitome.configuration.parent_controller.constantize
   layout Apitome.configuration.layout
 
   helper_method *[

--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -1,6 +1,6 @@
 require 'open-uri'
 
-class Apitome::DocsController < Apitome.configuration.parent_controller.constantize
+class Apitome::DocsController < Object.const_get(Apitome.configuration.parent_controller)
   layout Apitome.configuration.layout
 
   helper_method *[

--- a/lib/apitome/configuration.rb
+++ b/lib/apitome/configuration.rb
@@ -4,6 +4,7 @@ module Apitome
       :mount_at,
       :root,
       :doc_path,
+      :parent_controller,
       :title,
       :layout,
       :code_theme,
@@ -16,19 +17,20 @@ module Apitome
       :url_formatter
     ]
 
-    @@mount_at     = "/api/docs"
-    @@root         = nil # will default to Rails.root if left unset
-    @@doc_path     = "doc/api"
-    @@title        = "Apitome Documentation"
-    @@layout       = "apitome/application"
-    @@code_theme   = "default"
-    @@css_override = nil
-    @@js_override  = nil
-    @@readme       = "../api.md"
-    @@single_page  = true
-    @@remote_docs  = false
-    @@remote_url   = nil
-    @@url_formatter = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z]+/i, '-') }
+    @@mount_at          = "/api/docs"
+    @@root              = nil # will default to Rails.root if left unset
+    @@doc_path          = "doc/api"
+    @@parent_controller = "ActionController::Base"
+    @@title             = "Apitome Documentation"
+    @@layout            = "apitome/application"
+    @@code_theme        = "default"
+    @@css_override      = nil
+    @@js_override       = nil
+    @@readme            = "../api.md"
+    @@single_page       = true
+    @@remote_docs       = false
+    @@remote_url        = nil
+    @@url_formatter     = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z]+/i, '-') }
 
     def self.root=(path)
       @@root = Pathname.new(path.to_s) if path.present?

--- a/lib/generators/apitome/install/templates/initializer.rb
+++ b/lib/generators/apitome/install/templates/initializer.rb
@@ -12,6 +12,10 @@ Apitome.setup do |config|
   # configurable here.
   config.doc_path = "doc/api"
 
+  # Set a parent controller that Apitome::DocsController inherits from. Useful if you want to use a custom
+  # `before_action`.
+  config.parent_controller = "ActionController::Base"
+
   # The title of the documentation -- If your project has a name, you'll want to put it here.
   config.title = "Apitome Documentation"
 

--- a/spec/apitome/configuration_spec.rb
+++ b/spec/apitome/configuration_spec.rb
@@ -1,5 +1,17 @@
 require "spec_helper"
 
 describe Apitome::Configuration do
-  it "should be tested"
+  describe 'parent_controller' do
+    class TestController < ActionController::Base; end
+
+    before do
+      Apitome.setup do |config|
+        config.parent_controller = 'TestController'
+      end
+    end
+
+    it 'inherits from the TestController' do
+      expect(Apitome::DocsController).to be < TestController
+    end
+  end
 end


### PR DESCRIPTION
Hi,

I added a `parent_controller` config (inspired by Devise) to allow users to set a controller for `Apitome::DocsController` to inherit from. This makes it a lot easier to do things like custom auth for the docs endpoint.