### PR TITLE
Add configuration option for manual asset compilation control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 rvm:
-  - 2.2.0
+  - 2.3.0
+  - 2.4.0
+  - 2.5.0
 before_script:
   - sh -e /etc/init.d/xvfb start
 env:
   global:
     - TRAVIS=true
     - DISPLAY=:99.0
-before_install: 
+before_install:
   - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-ruby "2.2.0"
 source "https://rubygems.org"
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ After installation, your app will have an apitome initializer (app/config/initia
 
   <b>default:</b> <code>-> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z]+/i, '-') }</code>
 </dd>
+
+<dt> precompile_assets </dt><dd>
+  By default all assets that ship with this library are precompiled by the asset pipeline. If you would prefer to control this yourself, you can disable it by changing this to false.<br/>
+
+  <b>default:</b> <code>true</code>
+</dd>
 =======
 
 When you install Apitime an initializer file (app/config/initializers/apitome.rb) is generated that contains good

--- a/apitome.gemspec
+++ b/apitome.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency "railties"
   s.add_development_dependency "rspec_api_documentation"
   s.add_dependency "kramdown"
+
+  s.required_ruby_version = '~> 2.3'
 end

--- a/lib/apitome/configuration.rb
+++ b/lib/apitome/configuration.rb
@@ -15,7 +15,7 @@ module Apitome
       :remote_docs,
       :remote_url,
       :url_formatter,
-      :precompile
+      :precompile_assets
     ]
 
     @@mount_at          = "/api/docs"

--- a/lib/apitome/configuration.rb
+++ b/lib/apitome/configuration.rb
@@ -14,7 +14,8 @@ module Apitome
       :single_page,
       :remote_docs,
       :remote_url,
-      :url_formatter
+      :url_formatter,
+      :precompile
     ]
 
     @@mount_at          = "/api/docs"
@@ -31,6 +32,7 @@ module Apitome
     @@remote_docs       = false
     @@remote_url        = nil
     @@url_formatter     = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z]+/i, '-') }
+    @@precompile_assets = true
 
     def self.root=(path)
       @@root = Pathname.new(path.to_s) if path.present?

--- a/lib/apitome/engine.rb
+++ b/lib/apitome/engine.rb
@@ -2,12 +2,14 @@ module Apitome
   class Engine < ::Rails::Engine
     isolate_namespace Apitome
 
-    if Apitome.configuration.precompile_assets == true && config.respond_to?(:assets)
+    if Apitome.configuration.precompile_assets && config.respond_to?(:assets)
       config.assets.precompile += %w{apitome/*.css apitome/*.js}
+    else
+      config.assets.precompile += %w{} # Have to set this to empty for it to work
     end
 
-    # config.assets.paths << root.join('assets', 'stylesheets').to_s
-    # config.assets.paths << root.join('assets', 'javascripts').to_s
+    config.assets.paths << root.join('assets', 'stylesheets').to_s
+    config.assets.paths << root.join('assets', 'javascripts').to_s
 
     initializer :assets, group: :all do |app|
       # default the root if it's not set

--- a/lib/apitome/engine.rb
+++ b/lib/apitome/engine.rb
@@ -2,7 +2,7 @@ module Apitome
   class Engine < ::Rails::Engine
     isolate_namespace Apitome
 
-    if Apitome.configuration.precompile_assets && config.respond_to? (:assets)
+    if Apitome.configuration.precompile_assets && config.respond_to?(:assets)
       config.assets.precompile += %w{apitome/*.css apitome/*.js}
     end
 

--- a/lib/apitome/engine.rb
+++ b/lib/apitome/engine.rb
@@ -2,12 +2,12 @@ module Apitome
   class Engine < ::Rails::Engine
     isolate_namespace Apitome
 
-    if Apitome.configuration.precompile_assets && config.respond_to?(:assets)
+    if Apitome.configuration.precompile_assets == true && config.respond_to?(:assets)
       config.assets.precompile += %w{apitome/*.css apitome/*.js}
     end
 
-    config.assets.paths << root.join('assets', 'stylesheets').to_s
-    config.assets.paths << root.join('assets', 'javascripts').to_s
+    # config.assets.paths << root.join('assets', 'stylesheets').to_s
+    # config.assets.paths << root.join('assets', 'javascripts').to_s
 
     initializer :assets, group: :all do |app|
       # default the root if it's not set

--- a/lib/apitome/engine.rb
+++ b/lib/apitome/engine.rb
@@ -2,9 +2,12 @@ module Apitome
   class Engine < ::Rails::Engine
     isolate_namespace Apitome
 
-    if config.respond_to? (:assets)
+    if Apitome.configuration.precompile_assets && config.respond_to? (:assets)
       config.assets.precompile += %w{apitome/*.css apitome/*.js}
     end
+
+    config.assets.paths << root.join('assets', 'stylesheets').to_s
+    config.assets.paths << root.join('assets', 'javascripts').to_s
 
     initializer :assets, group: :all do |app|
       # default the root if it's not set

--- a/lib/generators/apitome/install/templates/initializer.rb
+++ b/lib/generators/apitome/install/templates/initializer.rb
@@ -49,7 +49,7 @@ Apitome.setup do |config|
   config.url_formatter = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z\:]+/i, '-') }
 
   # You can setup the docs to be loaded from a remote URL if they are
-  # not available in the application environment. This defaujlts to
+  # not available in the application environment. This defaults to
   # false.
   config.remote_docs = false
 
@@ -58,4 +58,8 @@ Apitome.setup do |config|
   # the readme is located. It uses the doc_path setting to build the
   # URLs for the API documentation. This defaults to nil.
   config.remote_url = nil
+
+  # If you would like to precompile your own assets, you can disable auto-compilation.
+  # This defaults to true
+  config.precompile_assets = true
 end


### PR DESCRIPTION
## Background

On projects where CSS and JS is off-loaded to a CDN or S3 bucket, we were generating a bunch of extra highlight.js styles we were never using. We wanted a way to disable that and control what is compiled inside the parent application.

## Changes

* Add `precompile_assets` flag, still defaulting to `true`
* Fixed a typo in the configuration
* Fixed a syntax error with `#respond_to? (:assets)` having a space, Ruby 2.5 won't allow that.
* Expose the Rails Engine asset paths to the parent application

#### Minor other changes

* Moved the Ruby version minimum into the `.gemspec` so it can run with newer Ruby versions.
* Update `.travis.yml` to have a run matrix against all current Ruby versions