### PR TITLE
Fix: Path independence

### DIFF
--- a/app/views/apitome/docs/_example.html.erb
+++ b/app/views/apitome/docs/_example.html.erb
@@ -17,7 +17,7 @@
 
     <h3><%= t(:response, scope: :apitome) %></h3>
     <div class="response">
-      <%= link_to('Simulated Response', apitome.simulated_path(link)) unless link.empty? %>
+      <%= link_to('Simulated Response', simulated_path(link)) unless link.empty? %>
       <%= render partial: 'apitome/docs/response_fields', locals: {params: example['response_fields']} if example['response_fields'].size > 0 %>
       <%= render partial: 'apitome/docs/status',          locals: {request: request, index: index} %>
       <%= render partial: 'apitome/docs/headers',         locals: {request: request, index: index, headers: request['response_headers']} %>


### PR DESCRIPTION
this `apitome.` is unnecessary since the engine is namespace isolated. Removing it allows to mount one (or more) `Apitome::Engine` on a custom path.