### PR TITLE
fixes an issue with locals in partials occurring with rails 5.1.6

### DIFF
--- a/app/views/apitome/docs/show.html.erb
+++ b/app/views/apitome/docs/show.html.erb
@@ -1,3 +1,3 @@
 <h1 class="resource-name"><%= example['resource'] %></h1>
 <%= render partial: 'resource_explanation', locals: { explanation: example['resource_explanation'] } if example['resource_explanation'] %>
-<%= render partial: 'example', locals: { example: example, link: example['link'].to_s.gsub('.json', '') } %>
+<%= render partial: 'example', example: example, link: example['link'].to_s.gsub('.json', '') %>


### PR DESCRIPTION
Using the longhand for passing locals to a partial when configured to render individual documentation pages raises a NameError. Using the shorthand seems to work as expected.

The issue on the rails side is discussed further here:
https://github.com/rails/rails/issues/31680

