### PR TITLE
Build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 log/*.log
 pkg/
+tmp/
 spec/dummy/log/*.log
 spec/dummy/tmp/
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,8 @@ env:
     - TRAVIS=true
     - DISPLAY=:99.0
 before_install:
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
+  - mkdir -p geckodriver
+  - tar -xzf geckodriver-v0.21.0-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ rvm:
   - 2.3.0
   - 2.4.0
   - 2.5.0
+addons:
+  chrome: stable
 before_script:
   - sh -e /etc/init.d/xvfb start
 env:
@@ -9,8 +11,4 @@ env:
     - TRAVIS=true
     - DISPLAY=:99.0
 before_install:
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
-  - mkdir -p geckodriver
-  - tar -xzf geckodriver-v0.21.0-linux64.tar.gz -C geckodriver
-  - export PATH=$PATH:$PWD/geckodriver
   - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   gem "puma"
   gem "aruba"
   gem "selenium-webdriver"
+  gem "chromedriver-helper"
 
   # io services
   gem "rubocop", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   # test dependencies
   gem "rspec-rails"
   gem "capybara"
+  gem "puma"
   gem "aruba"
   gem "selenium-webdriver"
 

--- a/spec/apitome/configuration_spec.rb
+++ b/spec/apitome/configuration_spec.rb
@@ -8,6 +8,11 @@ describe Apitome::Configuration do
       Apitome.setup do |config|
         config.parent_controller = 'TestController'
       end
+      if Apitome.const_defined?(:DocsController)
+        # If the class is already loaded, it needs re-loaded to pick up the config change
+        Apitome.send(:remove_const, :DocsController)
+        load "apitome/docs_controller.rb"
+      end
     end
 
     it 'inherits from the TestController' do

--- a/spec/features/installation_spec.rb
+++ b/spec/features/installation_spec.rb
@@ -8,12 +8,13 @@ feature "Installation", shell: true do
     cd("testapp")
 
     append_to_file("Gemfile", %{\ngem 'apitome', path: '../../../'\n})
-    run_simple("bundle install#{!ENV["TRAVIS"] ? ' --local' : ''}")
+    run_simple("bundle install")
   end
 
   it "installs the base files" do
     run_simple("bundle exec rails generate apitome:install --trace")
-    expect(all_output).to include(<<-OUTPUT.strip_heredoc)
+    out = all_commands.map { |c| c.output }.join("\n")
+    expect(out).to include(<<-OUTPUT.strip_heredoc)
             create  config/initializers/apitome.rb
             create  doc/api.md
             create  public/javascripts/apitome/application.js
@@ -25,7 +26,8 @@ feature "Installation", shell: true do
 
   it "can install without the asset files" do
     run_simple("bundle exec rails generate apitome:install --no-assets --trace")
-    expect(all_output).to include(<<-OUTPUT.strip_heredoc)
+    out = all_commands.map { |c| c.output }.join("\n")
+    expect(out).to include(<<-OUTPUT.strip_heredoc)
             create  config/initializers/apitome.rb
             create  doc/api.md
       +============================================================================+

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -43,37 +43,30 @@ feature "Reading in the browser", browser: true do
     visit "/api/docs"
 
     expect(page).to have_text(<<-TEXT.strip_heredoc)
-      A user access token is not always explicitly required, for instance if the user is unable to sign in and a
-      password reset is desired, or similarly, you may want to confirm username/email availability during registration.
-      For these types of requests only a client access token is required.
+      A user access token is not always explicitly required, for instance if the user is unable to sign in and a password reset is desired, or similarly, you may want to confirm username/email availability during registration. For these types of requests only a client access token is required.
     TEXT
 
     expect(page).to have_text(<<-TEXT.strip_heredoc)
       Endpoint
-
       POST /api/oauth/token
     TEXT
 
     expect(page).to have_text(<<-TEXT.strip_heredoc)
       Parameters
-
-      Name                    Description                   Expected
-      client_id required      Client ID (as provided)
-      client_secret required  Client Secret (as provided)
-      grant_type required     Grant Type                    client_credentials
+      Name Description Expected
+      client_id required Client ID (as provided)
+      client_secret required Client Secret (as provided)
+      grant_type required Grant Type client_credentials
     TEXT
 
     expect(page).to have_text(<<-TEXT.strip_heredoc)
       Request
-
       Route
       POST /api/oauth/token
-
       Headers
       Content-Type: application/json
       Host: example.com
-      Cookie:
-
+      Cookie: 
       Body
       {
         "client_id": "04e83c5f62d57a5458c8fd970cf499677156274ab02895cf8dabcc6e07beb2b1",
@@ -84,10 +77,8 @@ feature "Reading in the browser", browser: true do
 
     expect(page).to have_text(<<-TEXT.strip_heredoc)
       Response
-
       Status
       200
-
       Headers
       X-Frame-Options: SAMEORIGIN
       X-XSS-Protection: 1; mode=block
@@ -99,7 +90,6 @@ feature "Reading in the browser", browser: true do
       X-Request-Id: abd02f7a-26a8-4757-8157-0540e97ba8c5
       X-Runtime: 0.020698
       Content-Length: 123
-
       Body
       {
         "access_token": "7200227cb2d451f60e7c8a36c94793b06e1006a32d3282e47b73b3fb0605906d",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,12 +25,12 @@ RSpec.configure do |config|
 
   config.before(:each, shell: true) do
     @aruba_timeout_seconds = 180
-    clean_current_dir
+    setup_aruba
   end
 
   config.after(:each, shell: true) do
     restore_env
-    clean_current_dir
+    setup_aruba
   end
 
   config.before(:each, browser: true) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,5 +35,8 @@ RSpec.configure do |config|
 
   config.before(:each, browser: true) do
     Capybara.current_driver = Capybara.javascript_driver
+    Capybara.register_driver :selenium do |app|
+      Capybara::Selenium::Driver.new(app, browser: :chrome)
+    end
   end
 end


### PR DESCRIPTION
- Replaces deprecated `clean_current_dir` & `all_output` aruba methods
- Fixed expectations for whitespace in the specs
- Explicitly includes puma as a test dependency
- Gitignores the `/tmp` directory
- Uses chromedriver instead of geckodriver (the helper gem makes it easier)