### PR TITLE
Allow for HTTP Basic Auth for Remote docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ After installation, your app will have an apitome initializer (app/config/initia
 
   <b>default:</b> <code>true</code>
 </dd>
+
+<dt> http_basic_authentication </dt><dd>
+  If <code>remote_url</code> is enabled, you can fetch the remote docs using HTTP Basic Authentication by setting the configuration to an array of the user and password. Usage: <code>http_basic_authentication = ['user', 'password']</code><br/>
+
+  <b>default:</b> <code>nil</code>
+</dd>
 =======
 
 When you install Apitime an initializer file (app/config/initializers/apitome.rb) is generated that contains good

--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -42,13 +42,13 @@ class Apitome::DocsController < Object.const_get(Apitome.configuration.parent_co
         "#{Apitome.configuration.doc_path}/#{file}"
       end
 
-      file = "#{Apitome.configuration.remote_url}/#{file}"
+      file = URI.encode("#{Apitome.configuration.remote_url}/#{file}")
     else
       file = Apitome.configuration.root.join(Apitome.configuration.doc_path, file)
       raise Apitome::FileNotFoundError.new("Unable to find #{file}") unless File.exists?(file)
     end
 
-    open(file).read
+    open(file, file_opts).read
   end
 
   def resources
@@ -61,6 +61,16 @@ class Apitome::DocsController < Object.const_get(Apitome.configuration.parent_co
 
   def set_example(resource)
     @example = JSON.parse(file_for("#{resource}.json"))
+  end
+
+  def file_opts
+    if Apitome.configuration.remote_docs && Apitome.configuration.http_basic_authentication
+      {
+        http_basic_authentication: Apitome.configuration.http_basic_authentication
+      }
+    else
+      {}
+    end
   end
 
   def formatted_readme

--- a/lib/apitome/configuration.rb
+++ b/lib/apitome/configuration.rb
@@ -15,24 +15,26 @@ module Apitome
       :remote_docs,
       :remote_url,
       :url_formatter,
-      :precompile_assets
+      :precompile_assets,
+      :http_basic_authentication
     ]
 
-    @@mount_at          = "/api/docs"
-    @@root              = nil # will default to Rails.root if left unset
-    @@doc_path          = "doc/api"
-    @@parent_controller = "ActionController::Base"
-    @@title             = "Apitome Documentation"
-    @@layout            = "apitome/application"
-    @@code_theme        = "default"
-    @@css_override      = nil
-    @@js_override       = nil
-    @@readme            = "../api.md"
-    @@single_page       = true
-    @@remote_docs       = false
-    @@remote_url        = nil
-    @@url_formatter     = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z]+/i, '-') }
-    @@precompile_assets = true
+    @@mount_at                  = "/api/docs"
+    @@root                      = nil # will default to Rails.root if left unset
+    @@doc_path                  = "doc/api"
+    @@parent_controller         = "ActionController::Base"
+    @@title                     = "Apitome Documentation"
+    @@layout                    = "apitome/application"
+    @@code_theme                = "default"
+    @@css_override              = nil
+    @@js_override               = nil
+    @@readme                    = "../api.md"
+    @@single_page               = true
+    @@remote_docs               = false
+    @@remote_url                = nil
+    @@url_formatter             = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z]+/i, '-') }
+    @@precompile_assets         = true
+    @@http_basic_authentication = nil
 
     def self.root=(path)
       @@root = Pathname.new(path.to_s) if path.present?

--- a/lib/generators/apitome/install/templates/initializer.rb
+++ b/lib/generators/apitome/install/templates/initializer.rb
@@ -59,6 +59,12 @@ Apitome.setup do |config|
   # URLs for the API documentation. This defaults to nil.
   config.remote_url = nil
 
+  # If the remote_docs is set to true, and the remote URL is protected by
+  # HTTP Basic Authentication you can set the user and password here as an array.
+  # Usage: `http_basic_authentication = ['user', 'password']`.
+  # This defaults to nil.
+  config.http_basic_authentication = nil
+
   # If you would like to precompile your own assets, you can disable auto-compilation.
   # This defaults to true
   config.precompile_assets = true


### PR DESCRIPTION
This PR should allow someone to have their hosted files protected with HTTP Basic auth.

`open-uri` does not allow you to set the `user` and `password` in the url and you have to pass them in via the options. 