### PR TITLE
Use format_scope for response_fields partial

### DIFF
--- a/app/views/apitome/docs/_response_fields.html.erb
+++ b/app/views/apitome/docs/_response_fields.html.erb
@@ -11,7 +11,7 @@
         <tr>
           <td class="name">
             <% if param['scope'] %>
-              <%= "#{param['scope']}[#{param['name']}]" %>
+              <%= "#{format_scope(param['scope'])}[#{param['name']}]" %>
             <% else %>
               <%= param['name'] %>
             <% end %>

--- a/spec/helpers/docs_helper_spec.rb
+++ b/spec/helpers/docs_helper_spec.rb
@@ -26,4 +26,12 @@ describe Apitome::DocsHelper, type: :helper do
       expect(subject).to eq "/api/docs/an-example"
     end
   end
+
+  describe "#format_scope" do
+    it { expect(format_scope("")).to be_blank }
+    it { expect(format_scope("item")).to eq("item") }
+    it { expect(format_scope(:item)).to eq("item") }
+    it { expect(format_scope(%w[item item_id])).to eq("item[item_id]") }
+    it { expect(format_scope(%i[item item_id])).to eq("item[item_id]") }
+  end
 end


### PR DESCRIPTION
When using a nested scope for the response field method, such as:

```ruby
response_field :value, "A value", scope: [:item, :item_id]`
```
the HTML generated in the _Response Fields, Name_ column reads as:

```html
["item", "item_id"][value]
```

I believe the expected behavior is to display:

```html
item[item_id][value]
```

Using the `format_scope` helper fixes the issue. 

Also adds a few spec for the helper method.