### PR TITLE
Replace chromedriver-helper with webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rspec-rails"
 gem "capybara"
 gem "aruba", "~> 0.14.9"
 gem "selenium-webdriver"
-gem "chromedriver-helper"
+gem "webdrivers"
 gem "simplecov"
 
 # services

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require_relative "dummy/config/environment"
 require "rspec/rails"
 require "capybara/rails"
 require "aruba/rspec"
+require "webdrivers"
 require "apitome"
 
 def register_driver(name, args = [], opts = {})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,6 @@ RSpec.configure do |config|
   config.include Aruba::Api
 
   config.before(:each, browser: true) do
-    Capybara.default_driver = Capybara.javascript_driver = ENV.fetch("CAPYBARA_DRIVER", "chrome_headless").to_sym
+    Capybara.default_driver = Capybara.javascript_driver = ENV.fetch("CAPYBARA_DRIVER", "selenium_chrome_headless").to_sym
   end
 end


### PR DESCRIPTION
The chromedriver-helper project is unsupported as of 2019/03/13 and the project owner is encouraging developers to switch to the webdrivers gem. See https://github.com/flavorjones/chromedriver-helper/issues/83