### PR TITLE
Remove unnecessary error handling from formatted_body method

### DIFF
--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -80,14 +80,9 @@ class Apitome::DocsController < Object.const_get(Apitome.configuration.parent_co
     end
 
     def formatted_body(body, type)
-      if type =~ /json/ && body.present?
-        JSON.pretty_generate(JSON.parse(body))
-      else
-        body
-      end
-    rescue JSON::ParserError
       return body if body == " "
-      raise JSON::ParserError
+      return body unless type =~ /json/ && body.present?
+      JSON.pretty_generate(JSON.parse(body))
     end
 
     def param_headers(params)


### PR DESCRIPTION
I noticed this while digging down into the code here. The `if` was unnecessary, and so was rescuing an error in the specific case where `body == " "`, only to `return` the body anyway

I removed all that and replaced it with some guard clauses.