### PR TITLE
Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,16 @@ rvm:
   - 2.4.0
   - 2.5.0
   - 2.6.0
-services:
-  - xvfb
 addons:
   chrome: stable
 before_script:
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 before_install:
   - gem install bundler
 script:
-  - xvfb-run bundle exec rspec
+  - bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
 addons:
   chrome: stable
 before_script:
-  - sh -e /etc/init.d/xvfb start
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 2.4.0
   - 2.5.0
   - 2.6.0
+services:
+  - xvfb
 addons:
   chrome: stable
 before_script:
@@ -12,6 +14,6 @@ before_script:
 before_install:
   - gem install bundler
 script:
-  - bundle exec rspec
+  - xvfb-run bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -81,11 +81,17 @@ class Apitome::DocsController < Object.const_get(Apitome.configuration.parent_co
 
     def formatted_body(body, type)
       return body if body == " "
-      return body if body == "[binary data]"
+      return body if body == "[binary data]" # see https://github.com/zipmark/rspec_api_documentation/blob/560c3bdc7bd5581e7c223334390221ecfc910be8/lib/rspec_api_documentation/client_base.rb#L88-L96
       if type =~ /json/ && body.present?
         JSON.pretty_generate(JSON.parse(body))
       else
         body
+      end
+    rescue => e
+      if Apitome.configuration.formatted_body_error_handler
+        Apitome.configuration.formatted_body_error_handler.call(e, body, type)
+      else
+        raise
       end
     end
 

--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -80,14 +80,13 @@ class Apitome::DocsController < Object.const_get(Apitome.configuration.parent_co
     end
 
     def formatted_body(body, type)
+      return body if body == " "
+      return body if body == "[binary data]"
       if type =~ /json/ && body.present?
         JSON.pretty_generate(JSON.parse(body))
       else
         body
       end
-    rescue JSON::ParserError
-      return body if body == " "
-      raise JSON::ParserError
     end
 
     def param_headers(params)

--- a/app/views/apitome/docs/_example.html.erb
+++ b/app/views/apitome/docs/_example.html.erb
@@ -8,15 +8,26 @@
   <div id="<%= "request-#{index}" %>">
     <h3><%= t(:request, scope: :apitome) %></h3>
     <div class="request">
+      <% begin %>
       <%= render partial: 'apitome/docs/route',    locals: {request: request, index: index} %>
       <%= render partial: 'apitome/docs/headers',  locals: {request: request, index: index, headers: request['request_headers']} %>
       <%= render partial: 'apitome/docs/query',    locals: {request: request, index: index} unless request['request_query_parameters'].empty? %>
       <%= render partial: 'apitome/docs/body',     locals: {request: request, index: index, body: request['request_body'], type: request['request_content_type']} if request['request_body'] %>
       <%= render partial: 'apitome/docs/curl',     locals: {request: request, index: index} if request['curl'] %>
+      <%
+        rescue => e
+          if Apitome.configuration.example_error_handler
+            Apitome.configuration.example_error_handler.call(e, "request", request)
+          else
+            raise
+          end
+        end
+      %>
     </div>
 
     <h3><%= t(:response, scope: :apitome) %></h3>
     <div class="response">
+      <% begin %>
       <%- if Apitome.configuration.simulated_response %>
         <%= link_to('Simulated Response', simulated_path(example[:link])) if example[:link].present? %>
       <%- end %>
@@ -24,6 +35,15 @@
       <%= render partial: 'apitome/docs/status',          locals: {request: request, index: index} %>
       <%= render partial: 'apitome/docs/headers',         locals: {request: request, index: index, headers: request['response_headers']} %>
       <%= render partial: 'apitome/docs/body',            locals: {request: request, index: index, body: request['response_body'], type: request['response_content_type']} if request['response_body'] %>
+      <%
+        rescue => e
+          if Apitome.configuration.example_error_handler
+            Apitome.configuration.example_error_handler.call(e, "response", request)
+          else
+            raise
+          end
+        end
+      %>
     </div>
   </div>
 <% end %>

--- a/lib/apitome/configuration.rb
+++ b/lib/apitome/configuration.rb
@@ -21,6 +21,8 @@ module Apitome
       :http_basic_authentication,
       :precompile_assets,
       :simulated_response,
+      :formatted_body_error_handler,
+      :example_error_handler,
     ])
 
     @@mount_at = "/api/docs"
@@ -39,6 +41,8 @@ module Apitome
     @@http_basic_authentication = nil
     @@precompile_assets = true
     @@simulated_response = true
+    @@formatted_body_error_handler = nil
+    @@example_error_handler = nil
 
     def self.root=(path)
       @@root = Pathname.new(path.to_s) if path.present?

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link apitome/application.css
+//= link apitome/application.js
+//= link apitome/highlight_themes/default.css


### PR DESCRIPTION
1. Add test app manifest to the dummy app fixes some the spec test failures
1. Handle formatting acceptable non-json strings from rspec-api-documentation
1. Add general error handlers

no tests at this time.. just review for the shape of it, breaking it up, whatever

Fixes

- https://github.com/jejacks0n/apitome/issues/113
- https://github.com/jejacks0n/apitome/issues/114