### PR TITLE
Fix 'rails new testapp'  in feature/installation

### DIFF
--- a/spec/features/installation_spec.rb
+++ b/spec/features/installation_spec.rb
@@ -4,7 +4,7 @@ feature "Installation", shell: true do
   before do
     unset_bundler_env_vars
 
-    run_command_and_stop("bundle exec rails new testapp --skip-bundle --skip-activerecord")
+    run_command_and_stop("bundle exec rails new testapp --skip-bundle --skip-activerecord --skip-bootsnap --skip-webpack-install")
     cd("testapp")
 
     append_to_file("Gemfile", %{\ngem 'apitome', path: '../../../'\n})


### PR DESCRIPTION
Some of the build fail is from the fact that new rails app seems to have defaults some options that are not compatible with --skip-bundle.
https://github.com/rails/rails/issues/28916
So I had to add few other --skip-* options to make it work like the tests expects it to work