### PR TITLE
Don't display method param in list of parameters

### DIFF
--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -103,7 +103,7 @@ class Apitome::DocsController < Object.const_get(Apitome.configuration.parent_co
 
     def param_extras(params)
       params.map do |param|
-        param.reject { |k, _v| %w{name description required scope}.include?(k) }.keys
+        param.reject { |k, _v| %w{name description required scope method}.include?(k) }.keys
       end.flatten.uniq
     end
 


### PR DESCRIPTION
This extra param is only used internally to get the value of the parameter for spec examples.