### PR TITLE
fix compatibility issue with ruby 3.0.2

### DIFF
--- a/app/controllers/apitome/docs_controller.rb
+++ b/app/controllers/apitome/docs_controller.rb
@@ -62,7 +62,7 @@ class Apitome::DocsController < Object.const_get(Apitome.configuration.parent_co
       if Apitome.configuration.remote_url && Apitome.configuration.http_basic_authentication
         { http_basic_authentication: Apitome.configuration.http_basic_authentication }
       else
-        {}
+        nil
       end
     end
 


### PR DESCRIPTION
`open(file, {}).read` will throw the following error:
`TypeError: no implicit conversion of Hash into String`

causing the api files to not properly display.

The fix was simply to call `open(file, nil).read` when permissions are not required